### PR TITLE
Related animes small fixes

### DIFF
--- a/src/screens/related.rs
+++ b/src/screens/related.rs
@@ -913,7 +913,7 @@ impl RelatedScreen {
                     Style::default().fg(theme.text)
                 };
                 lines.push(Line::from(Span::styled(
-                    format!("{}{:<12} ▸ {}", marker, b.relation_label, b.title),
+                    format!("{}{:<19} ▸ {}", marker, b.relation_label, b.title),
                     style,
                 )));
             }

--- a/src/screens/widgets/animebox.rs
+++ b/src/screens/widgets/animebox.rs
@@ -102,7 +102,7 @@ impl AnimeBox {
 
         let user_stats_value_text = if anime.my_list_status.score > 0 {
             format!(
-                "{}★({})",
+                "{} ★{}",
                 anime.my_list_status.status, anime.my_list_status.score
             )
         } else {


### PR DESCRIPTION
Fix 1: 

Instead of "Completed★(10)", it will be "Completed ★10", which in my opinion looks a lot better. "Completed 10★" is also possible, but I don't know what the preference is of others and I am for now staying closer to what it was originally.


Fix 2: 

A series like Steins;Gate has related series labels like "Alternative version" and "Alternative setting", both consisting of 19 characters. Padding of 12 will make the list of related series look bad. 

This fix increases the padding to 19 which resolves this issue, as "Alternative version/setting" seem to be the longest possible labels on MyAnimeList.

However, it does increase the space between the label and the name by a lot for shorter labels. The question is whether this is an issue. This could be fixed by making the program such that it determines the largest label from all entries and decides the padding based on that, but that would change a lot of the logic and is probably not worth the hassle.


_These changes were made with the assistance of GitHub Copilot._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted branch entry text alignment and padding for improved readability.
  * Reformatted user rating display to include better spacing around the star icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->