### PR TITLE
Fix: Properly restore keyboard enhancement flags on exit

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -8,15 +8,14 @@ use crate::screens::BackgroundUpdate;
 use crate::screens::ScreenManager;
 use crate::utils::errorBus;
 use crate::utils::store::Store;
+use crate::utils::terminalCapabilities::set_input_flags;
+use crate::utils::terminalCapabilities::restore_input_flags;
 use crate::player;
 
 use database::DatabaseManager;
 use chrono::DateTime;
 use chrono::Local;
 use chrono::Utc;
-use crossterm::event::DisableMouseCapture;
-use crossterm::event::EnableMouseCapture;
-use crossterm::event::PopKeyboardEnhancementFlags;
 use image::DynamicImage;
 use ratatui::DefaultTerminal;
 use std::io;
@@ -253,7 +252,9 @@ impl App {
             episode
         };
 
-        crossterm::execute!(std::io::stderr(), DisableMouseCapture).ok();
+        if let Err(e) = restore_input_flags() {
+            self.screen_manager.show_error(format!("Failed to disable terminal modes: {e}"));
+        }
 
         match self
             .anime_player
@@ -300,8 +301,10 @@ impl App {
             }
         }
 
-        crossterm::execute!(std::io::stderr(), EnableMouseCapture).ok();
         self.terminal = ratatui::init();
+        if let Err(e) = set_input_flags() {
+            self.screen_manager.show_error(format!("Failed to restore terminal modes: {e}"));
+        }
         None
     }
 
@@ -381,8 +384,8 @@ impl App {
 impl Drop for App {
     fn drop(&mut self) {
         // restore terminal
+
+        restore_input_flags().ok();
         ratatui::restore();
-        crossterm::execute!(std::io::stderr(), DisableMouseCapture).ok();
-        crossterm::execute!(std::io::stdout(), PopKeyboardEnhancementFlags).ok();
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -303,7 +303,7 @@ impl App {
 
         self.terminal = ratatui::init();
         if let Err(e) = set_input_flags() {
-            self.screen_manager.show_error(format!("Failed to restore terminal modes: {e}"));
+            self.screen_manager.show_error(format!("Failed to set terminal input modes: {e}"));
         }
         None
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ use chrono::Local;
 use chrono::Utc;
 use crossterm::event::DisableMouseCapture;
 use crossterm::event::EnableMouseCapture;
+use crossterm::event::PopKeyboardEnhancementFlags;
 use image::DynamicImage;
 use ratatui::DefaultTerminal;
 use std::io;
@@ -382,5 +383,6 @@ impl Drop for App {
         // restore terminal
         ratatui::restore();
         crossterm::execute!(std::io::stderr(), DisableMouseCapture).ok();
+        crossterm::execute!(std::io::stdout(), PopKeyboardEnhancementFlags).ok();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
     let _ = Config::init();
     let _ = std::fs::create_dir_all(Config::data_dir()).is_ok();
 
-    // enable mouse capture, and enchanced keyboard input
+    // enable mouse capture, and enhanced keyboard input
     set_input_flags()?;
 
     // start the app

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,10 +7,7 @@ mod screens;
 mod utils;
 
 use crate::app::App;
-use crossterm::event::EnableMouseCapture;
-use crossterm::event::PushKeyboardEnhancementFlags;
-use crossterm::event::KeyboardEnhancementFlags;
-use crossterm::execute;
+use crate::utils::terminalCapabilities::set_input_flags;
 use anyhow::Result;
 use config::Config;
 
@@ -70,22 +67,11 @@ async fn main() -> Result<()> {
     Config::migrate_from_mal_cli();
 
     let terminal = ratatui::init();
-    let config = Config::init();
+    let _ = Config::init();
     let _ = std::fs::create_dir_all(Config::data_dir()).is_ok();
 
-
-    // enable mouse capture
-    if config.navigation.enable_mouse_capture {
-        execute!(std::io::stderr(), EnableMouseCapture)?;
-    }
-        execute!(
-        std::io::stdout(),
-            PushKeyboardEnhancementFlags(
-            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-            | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-        )
-    )?;
-
+    // enable mouse capture, and enchanced keyboard input
+    set_input_flags()?;
 
     // start the app
     let mut app = App::new(terminal);

--- a/src/utils/terminalCapabilities.rs
+++ b/src/utils/terminalCapabilities.rs
@@ -1,6 +1,14 @@
 use ratatui_image::picker::Picker;
 use std::{sync::OnceLock, thread, time::Duration};
-use crate::send_error;
+use crate::{config::Config, send_error};
+
+use crossterm::execute;
+use crossterm::event::EnableMouseCapture;
+use crossterm::event::PushKeyboardEnhancementFlags;
+use crossterm::event::KeyboardEnhancementFlags;
+use crossterm::event::DisableMouseCapture;
+use crossterm::event::PopKeyboardEnhancementFlags;
+
 
 static GLOBAL_PICKER: OnceLock<Picker> = OnceLock::new();
 pub const TERMINAL_RATIO: f32 = 2.20; // terminal "pixel" ratio (length to width of a single pixel)
@@ -68,4 +76,29 @@ impl TerminalCapabilities {
 
 pub fn get_picker() -> &'static Picker {
     TerminalCapabilities::instance().picker()
+}
+
+pub fn set_input_flags() -> std::io::Result<()> {
+    // enable mouse capture
+    if Config::global().navigation.enable_mouse_capture {
+        execute!(std::io::stderr(), EnableMouseCapture)?;
+    }
+
+    execute!(
+        std::io::stdout(),
+            PushKeyboardEnhancementFlags(
+            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+            | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
+        )
+    )?;
+
+    Ok(())
+}
+
+pub fn restore_input_flags() -> std::io::Result<()> {
+    // disable mouse capture
+    crossterm::execute!(std::io::stdout(), PopKeyboardEnhancementFlags).ok();
+    crossterm::execute!(std::io::stderr(), DisableMouseCapture).ok();
+
+    Ok(())
 }

--- a/src/utils/terminalCapabilities.rs
+++ b/src/utils/terminalCapabilities.rs
@@ -96,9 +96,9 @@ pub fn set_input_flags() -> std::io::Result<()> {
 }
 
 pub fn restore_input_flags() -> std::io::Result<()> {
-    // disable mouse capture
-    crossterm::execute!(std::io::stdout(), PopKeyboardEnhancementFlags).ok();
-    crossterm::execute!(std::io::stderr(), DisableMouseCapture).ok();
+    // run both regardless of an early failure 
+    let popped = crossterm::execute!(std::io::stdout(), PopKeyboardEnhancementFlags);
+    let mouse = crossterm::execute!(std::io::stderr(), DisableMouseCapture);
 
-    Ok(())
+    popped.and(mouse)
 }


### PR DESCRIPTION
## Description

### Problem
When mal-tui exits, the terminal is left in an inconsistent state with keyboard enhancement flags still enabled. This causes subsequent input for other programs in the same terminal session to be interpreted incorrectly, resulting in garbled text like `9;133u` instead of normal input.

This issue is confirmed for Kitty.

### Root Cause
The app enables keyboard enhancement flags (`DISAMBIGUATE_ESCAPE_CODES` and `REPORT_EVENT_TYPES`) on startup in `src/main.rs`, but these flags are never explicitly disabled when the app exits. While `ratatui::restore()` handles some terminal state restoration, it doesn't properly clean up the keyboard enhancement flags.

### Solution
Added `PopKeyboardEnhancementFlags` to the `Drop` implementation in `src/app.rs` to properly restore keyboard enhancement flags when the app exits, ensuring the terminal is left in a clean state.

### Changes
- Added import: `use crossterm::event::PopKeyboardEnhancementFlags;`
- Updated `Drop` implementation to execute `PopKeyboardEnhancementFlags` before app exit

---

These fixes and the description have been proposed by GitHub Copilot. Please review the pull request and test whether it fixes the problem. 

Steps to reproduce the issue: 
0. Have a terminal application installed where text can be inputted, such as nano, micro or even ani-cli when it is asking for a search query
1. Run mal-cli, do something in it
2. Exit mal-cli with ctrl+c
3. Run the other terminal application (micro used in the screenshot below)
4. Try to type something
5. Observe garbled text

<img width="1711" height="977" alt="image" src="https://github.com/user-attachments/assets/5136a35a-dd45-425d-b26f-e80ae08f289b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized terminal input initialization at startup with visible error reporting if setup fails.
* **Bug Fixes**
  * More reliable restoration of terminal input and mouse state on exit and after early failures to avoid leaving the terminal in an unusable state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->